### PR TITLE
Mock Date for footer tests

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -19,7 +19,8 @@ class Footer extends Component {
     return (
       <footer className="mt-5 text-right">
         <p>
-          &copy; {new Date().getFullYear()} {this.props.siteTitle}&nbsp;
+          &copy; {new Date(Date.now()).getFullYear()} {this.props.siteTitle}
+          &nbsp;
         </p>
         <Link to="/about">{t('about_us')}</Link> |&nbsp;
         <Link to="/privacy">{t('privacy_policy')}</Link> | {t('license_stmt')}

--- a/src/components/Footer.test.js
+++ b/src/components/Footer.test.js
@@ -3,6 +3,8 @@ import renderer from 'react-test-renderer';
 
 import Footer from './Footer';
 
+Date.now = jest.fn(() => new Date(2020, 0, 1, 12));
+
 describe('Footer', () => {
   it('renders correctly', () => {
     const tree = renderer.create(<Footer siteTitle="Footer Test" />).toJSON();


### PR DESCRIPTION
Fixes snapshot failure observed when it became 2020 that was addressed in #33 by just updating the snapshot. This addresses the issue long term, changing the component to call Date.now() and then mocking that function in the test so that it is will be 2020 forever.